### PR TITLE
Simplify and fix Packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 install: "pip install -r requirements.txt"
 
 script:
+ - git fetch --unshallow
  -
    if [ "$__" = "Build" ]; then
      python setup.py build;

--- a/pcpp/cmd.py
+++ b/pcpp/cmd.py
@@ -4,7 +4,15 @@ if __name__ == '__main__' and __package__ is None:
     sys.path.append( os.path.dirname( os.path.dirname( os.path.abspath(__file__) ) ) )
 from pcpp.preprocessor import Preprocessor, OutputDirective
 
-version='1.0.1'
+# Get current version of module
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    version = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__)
+
 
 __all__ = []
 

--- a/pcpp/cmd.py
+++ b/pcpp/cmd.py
@@ -7,7 +7,7 @@ from pcpp.preprocessor import Preprocessor, OutputDirective
 # Get current version of module
 from pkg_resources import get_distribution, DistributionNotFound
 try:
-    version = get_distribution(__name__).version
+    version = get_distribution('pcpp').version
 except DistributionNotFound:
     # package is not installed
     from setuptools_scm import get_version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ply>=3.10
+setuptools_scm>=1.15.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     entry_points={
         'console_scripts': [ 'pcpp=pcpp:main' ]
     },
-    install_requires=['ply'],
     setup_requires=['setuptools_scm'],
+    install_requires=['ply', 'setuptools_scm'],
     license='MIT',
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
-import os, pcpp
+import os
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -11,7 +11,7 @@ with open(os.path.join(here, 'Readme.rst')) as f:
     
 setup(
     name='pcpp',
-    version=pcpp.version,
+    use_scm_version=True,
     description='A C99 preprocessor written in pure Python',
     long_description=long_description,
     author='Niall Douglas and David Beazley',
@@ -22,6 +22,7 @@ setup(
         'console_scripts': [ 'pcpp=pcpp:main' ]
     },
     install_requires=['ply'],
+    setup_requires=['setuptools_scm'],
     license='MIT',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Hi,
I'm interested in using pcpp to pre-process headers automatically before usage with [cffi ](https://pypi.python.org/pypi/cffi) when creating new c-python bindings modules. It's looking good functionally in initial tests!

I've run into a couple of issues when installing pcpp however. 
The package on PyPI is missing a couple of things:
* Readme.rst is missing from the archive 
* setup.py imports pcpp (to get the version) which fails if the dependencies haven't been manually installed previously. 
This means that automatic dependency installation with pip fails.

I'm a huge fan of automating versioning and deployment of modules to avoid issues like this and make updates as painless as possible.

This pull request automates versioning with the excellent [setuptools_scm](https://github.com/pypa/setuptools_scm) (by the official pypa team) which calculates versions from the git tags. 

As such any time you want to release a new version you just make a new git tag (like "v1.0.2") and it's done. No source code modification is required.
This also means you get a release on [github releases page](https://github.com/ned14/pcpp/releases) automatically, providing convenient links to commits at each release.

Alternatively you can use the releases page on github to make the release and it'll make the tag for you, both work equally well.