### PR TITLE
Automate deployment to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 install: "pip install -r requirements.txt"
 
 script:
+ - git fetch --unshallow
  -
    if [ "$__" = "Build" ]; then
      python setup.py build;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,11 @@ script:
      git push -f https://jenkins-nedprod:$JENKINS_NEDPROD_PASSWORD@github.com/ned14/boost.outcome gh-pages;
      cd ../..;
    fi
+
+deploy:
+  provider: pypi
+  user: $PYPI_USERNAME
+  password: $PYPI_PASSWORD
+  distributions: "sdist bdist_wheel"
+  on:
+    tags: true

--- a/pcpp/cmd.py
+++ b/pcpp/cmd.py
@@ -4,7 +4,15 @@ if __name__ == '__main__' and __package__ is None:
     sys.path.append( os.path.dirname( os.path.dirname( os.path.abspath(__file__) ) ) )
 from pcpp.preprocessor import Preprocessor, OutputDirective
 
-version='1.0.1'
+# Get current version of module
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    version = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__)
+
 
 __all__ = []
 

--- a/pcpp/cmd.py
+++ b/pcpp/cmd.py
@@ -7,7 +7,7 @@ from pcpp.preprocessor import Preprocessor, OutputDirective
 # Get current version of module
 from pkg_resources import get_distribution, DistributionNotFound
 try:
-    version = get_distribution(__name__).version
+    version = get_distribution('pcpp').version
 except DistributionNotFound:
     # package is not installed
     from setuptools_scm import get_version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ply>=3.10
+setuptools_scm>=1.15.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     entry_points={
         'console_scripts': [ 'pcpp=pcpp:main' ]
     },
-    install_requires=['ply'],
     setup_requires=['setuptools_scm'],
+    install_requires=['ply', 'setuptools_scm'],
     license='MIT',
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
-import os, pcpp
+import os
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -11,7 +11,7 @@ with open(os.path.join(here, 'Readme.rst')) as f:
     
 setup(
     name='pcpp',
-    version=pcpp.version,
+    use_scm_version=True,
     description='A C99 preprocessor written in pure Python',
     long_description=long_description,
     author='Niall Douglas and David Beazley',
@@ -22,6 +22,7 @@ setup(
         'console_scripts': [ 'pcpp=pcpp:main' ]
     },
     install_requires=['ply'],
+    setup_requires=['setuptools_scm'],
     license='MIT',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This PR build on #2 to automate deployment of new releases to PyPI

Any time a new version tag is created, and travis tests pass, the package will be released to PyPI automatically.

This makes releasing a new version easier and less error-prone as all that's required is making a new git tag or a new release on the github releases page and a few minutes later it'll be updated on PyPI without having to remember the procedure.

Note: This modification to the travis hasn't been tested personally as it's dependent on your PyPI credentials being added to the travis repository secure variables as PYPI_USERNAME and PYPI_PASSWORD
https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings

It also assumes that secure environment variables work in the deployment stage. 
I typically use gitlab and it's built in ci for doing this rather than travis so not as familiar with the config and restrictions.

If this doesn't work the documented alternative is the secure variables generated with the travis command line client (which I haven't used either):
https://docs.travis-ci.com/user/deployment/pypi/
https://stackoverflow.com/a/33783088/3093392