### PR TITLE
Copy tokens before concatenating

### DIFF
--- a/pcpp/preprocessor.py
+++ b/pcpp/preprocessor.py
@@ -698,6 +698,7 @@ class Preprocessor(PreprocessorHooks):
                 j = i + 1
                 while rep[j].type == self.t_DPOUND:
                     j += 1
+                rep[i-1] = copy.copy(rep[i-1])
                 rep[i-1].type = self.t_ID
                 rep[i-1].value += rep[j].value
                 while j >= i:


### PR DESCRIPTION
Consider the following snippet:

    #define FOO(A, B) \
      A ## B a; \
      A ## B b; \
      A ## B c;
    FOO(x, y)

The output from `pcpp` is

    x_y_y_y a; x_y_y_y b; x_y_y_y c;

and not

    x_y a; x_y b; x_y c;

as you might expect. The problem looks to be that data shared between each 'A' substitution is being modified. Copying the `rep[i-1]` token before modifying it resolves the problem for me.

I've PR'd my change, if it's not the 'right' way to fix this I'm happy to contribute a different fix :)