### PR TITLE
Add option to preserve whitespace.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,8 @@ The help from the command line tool ``pcpp``::
     usage: pcpp [-h] [-o [path]] [-D macro[=val]] [-U macro] [-N macro] [-I path]
                 [--passthru-defines] [--passthru-unfound-includes]
                 [--passthru-unknown-exprs] [--passthru-comments]
-                [--disable-auto-pragma-once] [--line-directive [form]] [--debug]
+                [--disable-auto-pragma-once] [--line-directive [form]]
+                [--preserve-whitespace] [--debug]
                 [--time] [--filetimes [path]] [--version]
                 [input [input ...]]
 
@@ -121,6 +122,7 @@ The help from the command line tool ``pcpp``::
                             to be passed through instead of executed by treating
                             unknown macros as 0L
       --passthru-comments   Pass through comments unmodified
+      --preserve-whitespace Preserve whitespace in output
       --disable-auto-pragma-once
                             Disable the heuristics which auto apply #pragma once
                             to #include files wholly wrapped in an obvious include

--- a/pcpp/cmd.py
+++ b/pcpp/cmd.py
@@ -36,6 +36,7 @@ class CmdPreprocessor(Preprocessor):
         argp.add_argument('-U', dest = 'undefines', metavar = 'macro', nargs = 1, action = 'append', help = 'Pre-undefine name as a macro')
         argp.add_argument('-N', dest = 'nevers', metavar = 'macro', nargs = 1, action = 'append', help = 'Never define name as a macro, even if defined during the preprocessing.')
         argp.add_argument('-I', dest = 'includes', metavar = 'path', nargs = 1, action = 'append', help = "Path to search for unfound #include's")
+        argp.add_argument('--preserve-whitespace', dest = 'preserve_whitespace', action = 'store_true', help = 'Preserve whitespace in output')
         #argp.add_argument('--passthru', dest = 'passthru', action = 'store_true', help = 'Pass through everything unexecuted except for #include and include guards (which need to be the first thing in an include file')
         argp.add_argument('--passthru-defines', dest = 'passthru_defines', action = 'store_true', help = 'Pass through but still execute #defines and #undefs if not always removed by preprocessor logic')
         argp.add_argument('--passthru-unfound-includes', dest = 'passthru_unfound_includes', action = 'store_true', help = 'Pass through #includes not found without execution')
@@ -63,6 +64,7 @@ class CmdPreprocessor(Preprocessor):
             self.debugout = open("pcpp_debug.log", "wt")
         self.auto_pragma_once_enabled = not self.args.auto_pragma_once_disabled
         self.line_directive = self.args.line_directive
+        self.preserve_whitespace = self.args.preserve_whitespace
         
         # My own instance variables
         self.bypass_ifpassthru = False

--- a/pcpp/preprocessor.py
+++ b/pcpp/preprocessor.py
@@ -311,6 +311,7 @@ class Preprocessor(PreprocessorHooks):
         self.debugout = None
         self.auto_pragma_once_enabled = True
         self.line_directive = '#line'
+        self.preserve_whitespace = False
 
         # Probe the lexer for selected tokens
         self.__lexprobe()
@@ -1495,23 +1496,24 @@ class Preprocessor(PreprocessorHooks):
                 elif lastsource != toks[0].source:
                     emitlinedirective = True
                     lastsource = toks[0].source
-            # Replace consecutive whitespace in output with a single space except at any indent
-            first_ws = None
-            for n in xrange(len(toks)-1, -1, -1):
-                tok = toks[n]
-                if first_ws is None:
-                    if tok.type in self.t_SPACE or len(tok.value) == 0:
-                        first_ws = n
-                else:
-                    if tok.type not in self.t_SPACE and len(tok.value) > 0:
-                        m = n + 1
-                        while m != first_ws:
-                            del toks[m]
-                            first_ws -= 1
-                        first_ws = None
-                        # Collapse a token of many whitespace into single
-                        if toks[m].value[0] == ' ':
-                            toks[m].value = ' '
+            if not self.preserve_whitespace:
+                # Replace consecutive whitespace in output with a single space except at any indent
+                first_ws = None
+                for n in xrange(len(toks)-1, -1, -1):
+                    tok = toks[n]
+                    if first_ws is None:
+                        if tok.type in self.t_SPACE or len(tok.value) == 0:
+                            first_ws = n
+                    else:
+                        if tok.type not in self.t_SPACE and len(tok.value) > 0:
+                            m = n + 1
+                            while m != first_ws:
+                                del toks[m]
+                                first_ws -= 1
+                            first_ws = None
+                            # Collapse a token of many whitespace into single
+                            if toks[m].value[0] == ' ':
+                                toks[m].value = ' '
             if not emitlinedirective:
                 newlinesneeded = toks[0].lineno - lastlineno - 1
                 if newlinesneeded > 6 and self.line_directive is not None:


### PR DESCRIPTION
Adds Preprocessor instance variable `preserve_whitespace` that will disable the collapsing of
whitespace in output lines.  Defaults to False (behavior unchanged from previous versions).

Adds `--preserve-whitespace` option to pcpp command line utility.