### PR TITLE
Fixed some issues with multiline comments in pass-thru mode

### DIFF
--- a/pcpp/preprocessor.py
+++ b/pcpp/preprocessor.py
@@ -1484,7 +1484,6 @@ class Preprocessor(PreprocessorHooks):
         lastlineno = 0
         lastsource = None
         done = False
-        blankacc = []
         blanklines = 0
         while not done:
             emitlinedirective = False
@@ -1508,7 +1507,6 @@ class Preprocessor(PreprocessorHooks):
                 if len(toks) > 1:
                     tok = toks[-1]
                     toks = [ tok ]
-                blankacc.append(toks)
                 blanklines += toks[0].value.count('\n')
                 continue
             # The line in toks is not all whitespace
@@ -1548,15 +1546,12 @@ class Preprocessor(PreprocessorHooks):
             lastlineno = toks[0].lineno
             if emitlinedirective and self.line_directive is not None:
                 oh.write(self.line_directive + ' ' + str(lastlineno) + ('' if lastsource is None else (' "' + lastsource + '"' )) + '\n')
-            #elif blanklines > 0:
-            #    for line in blankacc:
-            #        for tok in line:
-            #            oh.write(tok.value)
-            blankacc = []
             blanklines = 0
             #print toks[0].lineno, 
             for tok in toks:
                 #print tok.value,
+                if tok.type == self.t_COMMENT1:
+                    lastlineno += tok.value.count('\n')
                 oh.write(tok.value)
             #print ''
 


### PR DESCRIPTION
(Getting to the point straight away:)

Sample input 1:

```

/*
multiline
comment
*/

void shouldBeOnLineSeven();
```

Output of `$ pcpp --passthru-comments test1.h` before patch:

```

/*
multiline
comment
*/




void shouldBeOnLineSeven();
```

Sample input 2:

```

/*
a
comment
that
spans
eight
lines
*/

void shouldBeOnLineEleven();
```

Output of `$ pcpp --passthru-comments test2.h` before patch:

```

/*
a
comment
that
spans
eight
lines
*/
#line 11 "test2.h"
void shouldBeOnLineEleven();
```

After patching, it correctly outputs the same output as the respective input. While the result of the second example is non-fatal, the first example shifts the line numbers illegally.

The fix addresses the problem with a rather simple trick of adjusting the last line number while iterating over the final token list. I also took the liberty of removing the blankacc list that wasn't used.