### PR TITLE
Add a "--no-include" option for "light-weighted" pre-processing.

### DIFF
--- a/pcpp/pcmd.py
+++ b/pcpp/pcmd.py
@@ -50,6 +50,7 @@ class CmdPreprocessor(Preprocessor):
         argp.add_argument('--time', dest = 'time', action = 'store_true', help = 'Print the time it took to #include each file')
         argp.add_argument('--filetimes', dest = 'filetimes', metavar = 'path', type = argparse.FileType('wt'), default=None, nargs = '?', help = 'Write CSV file with time spent inside each included file, inclusive and exclusive')
         argp.add_argument('--compress', dest = 'compress', action = 'store_true', help = 'Make output as small as possible')
+        argp.add_argument('--no-include', dest = 'no_include', action = 'store_true', help = 'Do not handle the #include directive')
         argp.add_argument('--version', action='version', version='pcpp ' + version)
         args = argp.parse_known_args(argv[1:])
         #print(args)

--- a/pcpp/pcmd.py
+++ b/pcpp/pcmd.py
@@ -69,7 +69,7 @@ class CmdPreprocessor(Preprocessor):
         self.auto_pragma_once_enabled = not self.args.auto_pragma_once_disabled
         self.line_directive = self.args.line_directive
         self.compress = 2 if self.args.compress else 0
-        self.no_include = self.args.no_include
+        self.no_include = True if self.args.no_include else False
         if self.args.passthru_magic_macros:
             self.undef('__DATE__')
             self.undef('__TIME__')

--- a/pcpp/pcmd.py
+++ b/pcpp/pcmd.py
@@ -69,6 +69,7 @@ class CmdPreprocessor(Preprocessor):
         self.auto_pragma_once_enabled = not self.args.auto_pragma_once_disabled
         self.line_directive = self.args.line_directive
         self.compress = 2 if self.args.compress else 0
+        self.no_include = self.args.no_include
         if self.args.passthru_magic_macros:
             self.undef('__DATE__')
             self.undef('__TIME__')

--- a/pcpp/preprocessor.py
+++ b/pcpp/preprocessor.py
@@ -1243,7 +1243,7 @@ class Preprocessor(PreprocessorHooks):
                             if handling is None:
                                 for tok in x:
                                     yield tok
-                    elif name == 'include':
+                    elif name == 'include' and not self.args.no_include:
                         if enable:
                             for tok in self.expand_macros(chunk):
                                 yield tok

--- a/pcpp/preprocessor.py
+++ b/pcpp/preprocessor.py
@@ -1243,7 +1243,7 @@ class Preprocessor(PreprocessorHooks):
                             if handling is None:
                                 for tok in x:
                                     yield tok
-                    elif name == 'include' and not self.args.no_include:
+                    elif name == 'include' and not self.no_include:
                         if enable:
                             for tok in self.expand_macros(chunk):
                                 yield tok

--- a/pcpp/preprocessor.py
+++ b/pcpp/preprocessor.py
@@ -393,6 +393,7 @@ class Preprocessor(PreprocessorHooks):
         self.auto_pragma_once_enabled = True
         self.line_directive = '#line'
         self.compress = False
+        self.no_include = False
 
         # Probe the lexer for selected tokens
         self.__lexprobe()


### PR DESCRIPTION
Add a "--no-include" option for "light-weighted" pre-processing, which will disable the handling of the #include directive. This can help me use pcpp to generate include map for a .c/.h file. And it can kind of meet the requirements from below links:

https://stackoverflow.com/questions/33409754/how-to-expand-macros-only-as-a-preprocessing-step-to-a-c-file
https://stackoverflow.com/questions/2615931/run-a-light-preprocessor-for-gcc