### PR TITLE
Fix bug where extra newlines are inserted when a multiline comment is encountered

### DIFF
--- a/pcpp/preprocessor.py
+++ b/pcpp/preprocessor.py
@@ -1717,11 +1717,12 @@ class Preprocessor(PreprocessorHooks):
                         oh.write('\n')
                         newlinesneeded -= 1
             lastlineno = toks[0].lineno
-            # Account for those newlines in a multiline comment
-            if toks[0].type == self.t_COMMENT1:
-                lastlineno += toks[0].value.count('\n')
             if emitlinedirective and self.line_directive is not None:
                 oh.write(self.line_directive + ' ' + str(lastlineno) + ('' if lastsource is None else (' "' + lastsource + '"' )) + '\n')
+            # Account for those newlines in a multiline comment
+            for tok in toks:
+                if tok.type == self.t_COMMENT1:
+                    lastlineno += tok.value.count('\n')
             blanklines = 0
             #print toks[0].lineno, 
             for tok in toks:

--- a/tests/issue0037.py
+++ b/tests/issue0037.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, print_function
+import unittest, sys
+
+shouldbe = r'''#line 1 "tests/issue0037/inc.h"
+    /** this spans
+        two lines */
+    virtual std::string baseOnly();
+'''
+
+class runner(object):
+    def runTest(self):
+        from pcpp import CmdPreprocessor
+        p = CmdPreprocessor(['pcpp', '--time', '--passthru-comments',
+                             '-o', 'tests/issue0037.i',
+                             'tests/issue0037/inc.h'])
+        with open('tests/issue0037.i', 'rt') as ih:
+            output = ih.read()
+        if output != shouldbe:
+            print("Should be:\n" + shouldbe + "EOF\n", file = sys.stderr)
+            print("\nWas:\n" + output + "EOF\n", file = sys.stderr)
+        self.assertEqual(p.return_code, 0)
+        self.assertEqual(output, shouldbe)
+
+class multiple_input_files(unittest.TestCase, runner):
+    pass

--- a/tests/issue0037/inc.h
+++ b/tests/issue0037/inc.h
@@ -1,0 +1,3 @@
+    /** this spans
+        two lines */
+    virtual std::string baseOnly();


### PR DESCRIPTION
- Error only occurs when preceded by whitespace
- Fixes #37 