### PR TITLE
Enable the 'nothing' in a `--line-directive` option.

### DIFF
--- a/pcpp/pcmd.py
+++ b/pcpp/pcmd.py
@@ -67,6 +67,8 @@ class CmdPreprocessor(Preprocessor):
             self.debugout = open("pcpp_debug.log", "wt")
         self.auto_pragma_once_enabled = not self.args.auto_pragma_once_disabled
         self.line_directive = self.args.line_directive
+        if self.line_directive.lower() in ("nothing", "none", ""):
+            self.line_directive = None
         self.compress = 2 if self.args.compress else 0
         if self.args.passthru_magic_macros:
             self.undef('__DATE__')

--- a/tests/line-directive-nothing.h
+++ b/tests/line-directive-nothing.h
@@ -1,0 +1,5 @@
+a1
+#if 0
+sample text
+#endif
+b1

--- a/tests/line-directive-nothing.py
+++ b/tests/line-directive-nothing.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, print_function
+import unittest
+import sys
+
+shouldbe = r'''a1
+
+
+
+b1
+'''
+
+
+class runner(object):
+    def runTest(self):
+        from pcpp import CmdPreprocessor
+        # failure: p = CmdPreprocessor(['pcpp', '--line-directive', '#line',
+        # p = CmdPreprocessor(['pcpp', '--line-directive', 'nothing',
+        # p = CmdPreprocessor(['pcpp', '--line-directive', 'None',
+        p = CmdPreprocessor(['pcpp', '--line-directive', '',
+                             '-o', 'tests/line-directive-nothing.i',
+                             'tests/line-directive-nothing.h'])
+        with open('tests/line-directive-nothing.i', 'rt') as ih:
+            output = ih.read()
+        if output != shouldbe:
+            print("Should be:\n" + shouldbe + "EOF\n", file=sys.stderr)
+            print("\nWas:\n" + output + "EOF\n", file=sys.stderr)
+        self.assertEqual(p.return_code, 0)
+        self.assertEqual(output, shouldbe)
+
+
+class multiple_input_files(unittest.TestCase, runner):
+    pass


### PR DESCRIPTION
this is the patch to fix `--line-directive` option,
help text discribe the behavior at `nothing` and
found the codes check line_directive to None.

but line_directive never set to None at pcmd.py 