### PR TITLE
preprocessor: preserve line continuations

### DIFF
--- a/pcpp/preprocessor.py
+++ b/pcpp/preprocessor.py
@@ -1517,7 +1517,7 @@ class Preprocessor(PreprocessorHooks):
                         print("x:x:x x:x #include \"%s\" skipped as already seen" % (fulliname), file = self.debugout)
                     return
                 try:
-                    ih = open(fulliname,"r")
+                    ih = open(fulliname,"r",encoding='utf8')
                     data = ih.read()
                     ih.close()
                     dname = os.path.dirname(fulliname)


### PR DESCRIPTION
Instead of concatenating lines ended with a backslash for further
lexing, preserve those by considering them as just another type
of whitespace. This causes yielded lex tokens for multiline macros
to have an accurate reported line number.

The changes in the reference output for tests are legitimate.