### PR TITLE
Rearranging how main() works (#73)

### DIFF
--- a/pcpp/pcmd.py
+++ b/pcpp/pcmd.py
@@ -247,10 +247,11 @@ class CmdPreprocessor(Preprocessor):
             return True  # Pass through
         return super(CmdPreprocessor, self).on_comment(tok)
 
-def main():
-    p = CmdPreprocessor(sys.argv)
-    sys.exit(p.return_code)
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
+    p = CmdPreprocessor(argv)
+    return p.return_code
         
 if __name__ == "__main__":
-    p = CmdPreprocessor(sys.argv)
-    sys.exit(p.return_code)
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
- Instead of duplicating the code in main() and the __main__ condition this uses only main()
- main() now takes a list as input (the argv list)
- main() returns the exit code instead of calling sys.exit()