### PR TITLE
Prevent errors due to infinite recursion in self-referential macros

### DIFF
--- a/pcpp/preprocessor.py
+++ b/pcpp/preprocessor.py
@@ -558,6 +558,9 @@ class Preprocessor(PreprocessorHooks):
         for tok in tokens:
             if not hasattr(tok, 'expanded_from'):
                 tok.expanded_from = []
+            # Break recursion
+            if len(expanding_from) == 1 and tok.value == expanding_from[0]:
+                return tokens
         i = 0
         #print("*** EXPAND MACROS in", "".join([t.value for t in tokens]), "expanding_from=", expanding_from)
         #print(tokens)

--- a/tests/issue0072-ref.i
+++ b/tests/issue0072-ref.i
@@ -1,0 +1,2 @@
+#line 5 "tests/issue0072.h"
+FOO(42);

--- a/tests/issue0072.h
+++ b/tests/issue0072.h
@@ -1,0 +1,5 @@
+#define MODIFY(x) x
+#define FOO MODIFY(FOO)
+#define DO_FOO FOO(42);
+
+DO_FOO

--- a/tests/issue0072.py
+++ b/tests/issue0072.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import, print_function
+import unittest
+
+class issue0072(unittest.TestCase):
+    def runTest(self):
+        from pcpp import Preprocessor
+        import os, sys
+
+        p = Preprocessor()
+        path = 'tests/issue0072.h'
+        with open(path, 'rt') as ih:
+            p.parse(ih.read(), path)
+        with open('tests/issue0072.i', 'w') as oh:
+            p.write(oh)
+        with open('tests/issue0072.i', 'r') as ih:
+            was = ih.read()
+        with open('tests/issue0072-ref.i', 'r') as ih:
+            shouldbe = ih.read()
+        if was != shouldbe:
+            print("Should be:\n" + shouldbe, file = sys.stderr)
+            print("\n\nWas:\n" + was, file = sys.stderr)
+        self.assertEqual(p.return_code, 0)
+        self.assertEqual(was, shouldbe)


### PR DESCRIPTION
Fixes: https://github.com/ned14/pcpp/issues/72

Patch based on work of @MatthewShao
Test created by stripping down the reproducing example in above issue.