### PR TITLE
Fix lineno for multiline char literals

### DIFF
--- a/pcpp/parser.py
+++ b/pcpp/parser.py
@@ -131,7 +131,6 @@ def t_CPP_STRING(t):
 # Character constant 'c' or L'c'
 def t_CPP_CHAR(t):
     r'(L)?\'([^\\\n]|(\\(.|\n)))*?\''
-    t.lexer.lineno += t.value.count("\n")
     return t
 
 # Comment


### PR DESCRIPTION
This avoids redundant newlines in the output when encountering a multiline char literal. I don't think multiline char literals are actually valid in C, but preserving the original whitespace is useful when mixed with other tooling.

Before:

```
'\(newline)  =>  '\(newline)
\(newline)       \(newline)
c'(newline)      c'(newline)
                 (newline)
                 (newline)
```
After:

```
'\(newline)  =>  '\(newline)
\(newline)       \(newline)
c'(newline)      c'(newline)
```

It looks like t_CPP_CHAR was trying to adjust the lineno for consumed newlines, but unlike t_CPP_STRING and t_CPP_COMMENT1, it doesn't actually consume any newlines.

---

As for how I even ran into this. I'm using pcpp to parse some, uh, non-C stuff, which pcpp's relaxed preprocessing is very useful for.

But I think this is unlikely to be encountered in real C code, so feel free to close if out-of-scope.

`python setup.py test` passed locally.